### PR TITLE
`no_std` and docs polish

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 /// Derives a fast `Hash` implementation for `bytemuck` types.
 ///
-/// This macro implements [std::hash::Hash] by calling `.bytes_of()` on the
+/// This macro implements [`core::hash::Hash`] by calling `.bytes_of()` on the
 /// struct, which leverages `bytemuck` to get a byte representation of the
 /// type for hashing.
 ///
@@ -50,7 +50,7 @@ macro_rules! derive_hash_fast_bytemuck {
 
 /// Derives a fast `Hash` implementation for `zerocopy` types.
 ///
-/// This macro implements [std::hash::Hash] by calling `.as_bytes()` on the
+/// This macro implements [`core::hash::Hash`] by calling `.as_bytes()` on the
 /// struct, which leverages `zerocopy` to get a byte representation of the
 /// type for hashing.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), no_std)]
+#![no_std]
 
 /// Derives a fast `Hash` implementation for `bytemuck` types.
 ///
@@ -171,6 +171,7 @@ fn hash_padded_large<const N: usize>(bytes: &[u8; N], state: &mut impl Hasher) {
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
     use super::*;
 
     #[repr(C)]


### PR DESCRIPTION
* Simplify `no_std` configuration.

  This way, the *non-test* code is not compiled with the std prelude present or absent depending on `cfg(test)`; only the test code involves `std` at all. This prevents accidentally introducing a `std` dependency and not noticing because you only ran `cargo test --lib` or such.

* Fix broken doc links to `std` instead of `core`.